### PR TITLE
Fix spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ exit()
 Runs a training instance locally
 ~~~
 cd ..
-cd ubutu/universe-starter-agent/
+cd ubuntu/universe-starter-agent/
 sudo python train.py --env-id flashgames.NeonRace-v0 --log-dir ~/NeonRace-v0 -w 2 --visualise
 ~~~
 


### PR DESCRIPTION
Change `cd ubutu/universe-starter-agent/` to `cd ubuntu/universe-starter-agent/`